### PR TITLE
fix: add capability for extractors to skip oauth authentication flow.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -180,6 +180,10 @@ export function cli(config) {
       },
       async (argv) => {
         const parsed = await parseConfig(argv.config);
+        if (!getOauthAuthenicator) {
+          console.log('Extractor does not support OAuth, skipping authentication!');
+          return;
+        }
         const authenticator = await getOauthAuthenicator(parsed);
         await performOauthAuthentication(authenticator, argv.port);
         console.log('Authenticated successfully!');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -75,4 +75,17 @@ describe('CLI Test', () => {
     assert(res.stderr.toString() === '');
     assert(res.stdout.toString().includes('Retrieved folders:'));
   });
+
+  it('can skip authentication', async () => {
+    const res = spawnSync('node', [
+      'test/mocks/mockcli.js',
+      'authenticate',
+      '--config',
+      'test/mocks/config.json',
+      '--port',
+      '3000',
+    ]);
+    assert(res.stderr.toString() === '');
+    assert(res.stdout.toString().includes('skipping authentication!'));
+  });
 });


### PR DESCRIPTION
## Related Issues

https://trello.com/c/5ZoCLJ5c/4-implement-stock-extractor-v0

The stock extractor authenticates with JWT instead of OAuth. This PR modifies the `authenticate` CLI command so that it skips the OAuth flow if an implementing CLI doesn't provide a value for `getOauthAuthenicator`.
