### PR TITLE
modify ingestor so that second call to get asset binary info is optional

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -32,6 +32,9 @@
  * @property {string | undefined} lastModifiedBy
  *  an identifier for the principal which last modified the asset
  * @property {string | undefined} path the path to the asset
+ * @property {BinaryRequest | undefined} [binary] If provided, information about the request
+ *  that can be sent to retrieve the asset's binary data. If missing, the ingestion process will
+ *  make a second call to the extractor to retrieve this information.
  */
 
 /**

--- a/src/ingestor.js
+++ b/src/ingestor.js
@@ -148,7 +148,12 @@ export class IngestorClient {
       jobId: this.#config.jobId,
     });
     const resolved = await mapLimit(batch.assets, limit || 1, async (data) => {
-      const binary = await extractor.getBinaryRequest(data.id);
+      let { binary } = data;
+      // some extractors may be able to provide binary information with the asset
+      // itself, eliminating the need to perform a second request
+      if (!binary) {
+        binary = await extractor.getBinaryRequest(data.id);
+      }
       return { data, binary };
     });
 

--- a/test/ingestor.test.js
+++ b/test/ingestor.test.js
@@ -65,6 +65,39 @@ describe('Ingestor Client Tests', function () {
     assert.ok(scope.isDone());
   });
 
+  it('Can support inline binary info', async () => {
+    const inlineExtractor = new MockExtractor([
+      {
+        assets: [
+          {
+            id: 1,
+            sourceId: 1,
+            sourceType: 'mock',
+            binary: {
+              requestType: 'http',
+              url: 'https://www.adobe.com/content/dam/cc/icons/Adobe_Corporate_Horizontal_Red_HEX.svg',
+            },
+          },
+        ],
+        more: false,
+      },
+    ]);
+    inlineExtractor.getBinaryRequest = async () => {
+      throw new Error('unit test error!');
+    };
+    const scope = nock(TEST_INGESTOR_URL)
+      .post('/')
+      .matchHeader('x-api-key', 'test-api-key')
+      .reply(200, 'Ok');
+    const client = new IngestorClient({
+      url: `${TEST_INGESTOR_URL}/`,
+      apiKey: 'test-api-key',
+      jobId: 'test-job-id',
+    }).withLog(console);
+    await client.submitBatch(inlineExtractor);
+    assert.ok(scope.isDone());
+  });
+
   it('Can set cursor', async () => {
     const scope = nock(TEST_INGESTOR_URL)
       .post('/')


### PR DESCRIPTION
## Related Issues

https://trello.com/c/5ZoCLJ5c/4-implement-stock-extractor-v0

The Stock extractor can provide information about an asset's binary (i.e. a thumbnail URL) as part of the asset listing itself. There's no need to make a second call to `getBinaryRequest`.

This PR modifies the `AssetData` type so that it can have an optional `binary` property. If this property is present, the ingestor will skip subsequent calls to retrieve the binary's url.
