### PR TITLE
pass all asset data into getBinaryRequest method.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -145,7 +145,7 @@ export function cli(config) {
       },
       async (argv) => {
         const extractor = await getExtractor(await parseConfig(argv.config));
-        const res = await extractor.getBinaryRequest(argv['asset-id']);
+        const res = await extractor.getBinaryRequest(argv['asset-id'], argv);
         console.log('Retrieved asset binary request:');
         console.log(res);
       },

--- a/src/ingestor.js
+++ b/src/ingestor.js
@@ -177,7 +177,7 @@ export class IngestorClient {
           // itself, eliminating the need to perform a second request
           if (!binary) {
             try {
-              binary = await extractor.getBinaryRequest(data.id);
+              binary = await extractor.getBinaryRequest(data.id, data);
             } catch (err) {
               this.#log.warn('Failed to retrieve binary', {
                 batchInfo,


### PR DESCRIPTION
## Related Issues

https://trello.com/c/5ZoCLJ5c/4-implement-stock-extractor-v0

The Stock extractor requires additional information from the asset in order to retrieve a binary url. Rather than change the existing `id` parameter, this PR adds a second parameter, which is all of the asset's info. This is to maintain backward compatibility with other extractors.
