### PR TITLE
fix: import Response used in RequestHandler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@adobe/content-lake-extractors-shared",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/content-lake-extractors-shared",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/content-lake-commons": "^1.3.0",
+        "@adobe/fetch": "^4.0.10",
         "@adobe/helix-shared-wrap": "^2.0.0",
         "@adobe/helix-status": "^10.0.4",
         "@adobe/helix-universal-logger": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@adobe/content-lake-commons": "^1.3.0",
+    "@adobe/fetch": "^4.0.10",
     "@adobe/helix-shared-wrap": "^2.0.0",
     "@adobe/helix-status": "^10.0.4",
     "@adobe/helix-universal-logger": "^3.0.5",

--- a/src/request-handler.js
+++ b/src/request-handler.js
@@ -19,6 +19,7 @@ import {
 import wrap from '@adobe/helix-shared-wrap';
 import { helixStatus } from '@adobe/helix-status';
 import { logger } from '@adobe/helix-universal-logger';
+import { Response } from '@adobe/fetch';
 
 /**
  * @callback HandlerFn


### PR DESCRIPTION
found while debugging:
[logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fhelix-services--content-lake-ingestor-service/log-events/2023$252F04$252F27$252F$255B358$255D265111a9e3954071a340fbdfb8c52c35$3Fstart$3DPT3H)
```


2023-04-27T16:13:21.704Z	0786f4e7-a30b-508e-bc2d-a823025600c6	DEBUG	Message removed successfully {  receiptHandle: 'AQEBlD9lwlhEIdsOVdNJ2w/MRCKLED2V7Prd0KCRelFTW1fi8Hw7K0lTA7N1K4CNtCLFE5SQoeApyJhp+1ywpjI9SY64jKIl3td/uuOW95hNmA5PLBZ6SPcA/EJY9CvYNvOCSIhUNjxw65tmPL4KpQkmCGm7mEsVlPP40wPJHWkTM6D3QAYhKMjBIX4bhCJRHAYUELSDbFOEtydn04bmx4yuqeaJUuSbp426yvoCTBju/vREgxBK3Jx4HdqAg8IjCGlV10MgJqSixagEXA6OgJ5askwIACJYFXYWBL+PDeoH8LxLm27KQvb8poRMpbhdvQlZa76UPJQAfccQtKIHsMcUdKb2je3avRU6JkBfpbXTQ52ESZBWL5ra09gjBGXYCBDaatw7pBIeuvFzP1DdvNVoDA==',  queueUrl: 'https://sqs.us-east-1.amazonaws.com/532042585738/content-lake-ingestor-queue'}
--
2023-04-27T16:13:21.705Z	0786f4e7-a30b-508e-bc2d-a823025600c6	WARN	Exception handling request {  method: 'GET',  url: 'https://undefined/',  headers: {},  invocation: {    id: '0786f4e7-a30b-508e-bc2d-a823025600c6',    deadline: 1682612300766,    transactionId: null,    requestId: undefined,    event: { Records: [Array] }  },  event: { Records: [ [Object] ] },  err: ReferenceError: Response is not defined      at RequestHandler.handleRequest (/var/task/index.js:58536:7)      at processTicksAndRejections (node:internal/process/task_queues:96:5)      at async /var/task/index.js:58478:15      at async /var/task/index.js:71196:24      at async lambdaAdapter (/var/task/index.js:75904:22)      at async Runtime.wrapped [as handler] (/var/task/index.js:75965:14)}


```

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
