### PR TITLE
fix: make the result of an invocation easier to consume via parsing a json

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -77,9 +77,7 @@ export class FunctionRunner {
       const resultData = FunctionRunner.resultData(result, data);
       const err = new Error('Invalid response body from function');
       err.status = 502;
-      err.detail = `Invalid response body from function: ${JSON.stringify(
-        resultData,
-      )}`;
+      err.detail = JSON.stringify(resultData);
       throw err;
     }
     return data;
@@ -113,9 +111,7 @@ export class FunctionRunner {
       this.#log.warn('Invalid result from function invocation', resultData);
       const err = new Error('Invalid result from function invocation');
       err.status = 502;
-      err.detail = `Invalid result from function invocation: ${JSON.stringify(
-        resultData,
-      )}`;
+      err.detail = JSON.stringify(resultData);
       throw err;
     }
   }


### PR DESCRIPTION
this way the caller can call `JSON.parse(error.detail)` if it wanted to take action on the result

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
