### PR TITLE
feat: add invocationId to function invoke result and logs for tracking and monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/content-lake-extractors-shared",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/content-lake-extractors-shared",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/content-lake-commons": "^1.3.0",

--- a/src/functions.js
+++ b/src/functions.js
@@ -77,9 +77,7 @@ export class FunctionRunner {
       const resultData = FunctionRunner.resultData(result, data);
       const err = new Error('Invalid response body from function');
       err.status = 502;
-      err.detail = `Invalid response body from function: ${JSON.stringify(
-        resultData,
-      )}`;
+      err.detail = JSON.stringify(resultData);
       throw err;
     }
     return data;
@@ -113,9 +111,7 @@ export class FunctionRunner {
       this.#log.warn('Invalid result from function invocation', resultData);
       const err = new Error('Invalid result from function invocation');
       err.status = 502;
-      err.detail = `Invalid result from function invocation: ${JSON.stringify(
-        resultData,
-      )}`;
+      err.detail = JSON.stringify(resultData);
       throw err;
     }
   }


### PR DESCRIPTION
It is helpful for monitoring and debugging to log the invocationId of the downstream request so we can more easily find it in coralogix. Additionally, send it back to the caller in case they want to do anything with it.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
