### PR TITLE
feat: add support for aws secret manager to request handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@adobe/content-lake-extractors-shared",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/content-lake-extractors-shared",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/content-lake-commons": "^1.3.0",
+        "@adobe/helix-shared-secrets": "^2.1.0",
         "@adobe/helix-shared-wrap": "^2.0.0",
         "@adobe/helix-status": "^10.0.4",
         "@adobe/helix-universal-logger": "^3.0.5",
@@ -113,6 +114,24 @@
         "polka": "^0.5.2"
       }
     },
+    "node_modules/@adobe/helix-shared-secrets": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-secrets/-/helix-shared-secrets-2.1.0.tgz",
+      "integrity": "sha512-QSts6zHavCGoQhAxd44aEr46nA776QxO2uF1mg0+LsdcAWuJuO/5PtLbbDcHLT4OniOAgOqV+8ZQMnp82ts+DA==",
+      "dependencies": {
+        "@adobe/fetch": "^4.0.1",
+        "@adobe/helix-shared-wrap": "^1.0.5",
+        "aws4": "^1.12.0"
+      },
+      "optionalDependencies": {
+        "@adobe/helix-universal": "^4.0.0"
+      }
+    },
+    "node_modules/@adobe/helix-shared-secrets/node_modules/@adobe/helix-shared-wrap": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.5.tgz",
+      "integrity": "sha512-g8bap0KhWI6Y6USlf9Se4t+Og0A6udYkoQH2NBdj/HOLnLozwn+60wbVLJhHIW2Ldt81xmhBqjhW0j1BtCQ3uw=="
+    },
     "node_modules/@adobe/helix-shared-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-2.0.0.tgz",
@@ -124,6 +143,16 @@
       "integrity": "sha512-4bhUCQHbsRBc/vWcd4JQl6IKG9341Ls64rpwEcULvvIz3CmUmwH3Fb4gXLtFcqG/2PxpedZP0xT8hEeEYNu/4g==",
       "dependencies": {
         "@adobe/fetch": "4.0.13"
+      }
+    },
+    "node_modules/@adobe/helix-universal": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-4.2.0.tgz",
+      "integrity": "sha512-V9gk+oZEBmnEcoK0gHPm7noGBnvuomS7UWOtrltEhwj/eZ3CkHxEPvqIp8F2rzTQ9fYAFn3c4V0f5XuQEfI8tw==",
+      "optional": true,
+      "dependencies": {
+        "@adobe/fetch": "4.0.13",
+        "aws4": "1.12.0"
       }
     },
     "node_modules/@adobe/helix-universal-logger": {
@@ -6895,6 +6924,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -17363,6 +17397,24 @@
         "polka": "^0.5.2"
       }
     },
+    "@adobe/helix-shared-secrets": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-secrets/-/helix-shared-secrets-2.1.0.tgz",
+      "integrity": "sha512-QSts6zHavCGoQhAxd44aEr46nA776QxO2uF1mg0+LsdcAWuJuO/5PtLbbDcHLT4OniOAgOqV+8ZQMnp82ts+DA==",
+      "requires": {
+        "@adobe/fetch": "^4.0.1",
+        "@adobe/helix-shared-wrap": "^1.0.5",
+        "@adobe/helix-universal": "^4.0.0",
+        "aws4": "^1.12.0"
+      },
+      "dependencies": {
+        "@adobe/helix-shared-wrap": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.5.tgz",
+          "integrity": "sha512-g8bap0KhWI6Y6USlf9Se4t+Og0A6udYkoQH2NBdj/HOLnLozwn+60wbVLJhHIW2Ldt81xmhBqjhW0j1BtCQ3uw=="
+        }
+      }
+    },
     "@adobe/helix-shared-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-2.0.0.tgz",
@@ -17374,6 +17426,16 @@
       "integrity": "sha512-4bhUCQHbsRBc/vWcd4JQl6IKG9341Ls64rpwEcULvvIz3CmUmwH3Fb4gXLtFcqG/2PxpedZP0xT8hEeEYNu/4g==",
       "requires": {
         "@adobe/fetch": "4.0.13"
+      }
+    },
+    "@adobe/helix-universal": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-4.2.0.tgz",
+      "integrity": "sha512-V9gk+oZEBmnEcoK0gHPm7noGBnvuomS7UWOtrltEhwj/eZ3CkHxEPvqIp8F2rzTQ9fYAFn3c4V0f5XuQEfI8tw==",
+      "optional": true,
+      "requires": {
+        "@adobe/fetch": "4.0.13",
+        "aws4": "1.12.0"
       }
     },
     "@adobe/helix-universal-logger": {
@@ -22821,6 +22883,11 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@adobe/content-lake-commons": "^1.3.0",
+    "@adobe/helix-shared-secrets": "^2.1.0",
     "@adobe/helix-shared-wrap": "^2.0.0",
     "@adobe/helix-status": "^10.0.4",
     "@adobe/helix-universal-logger": "^3.0.5",

--- a/src/request-handler.js
+++ b/src/request-handler.js
@@ -17,6 +17,7 @@ import {
   RestError,
 } from '@adobe/content-lake-commons';
 import wrap from '@adobe/helix-shared-wrap';
+import secrets from '@adobe/helix-shared-secrets';
 import { helixStatus } from '@adobe/helix-status';
 import { logger } from '@adobe/helix-universal-logger';
 import { Response } from 'node-fetch';
@@ -100,6 +101,7 @@ export class RequestHandler {
       log.info(`< ${method} ${res.status} ${url} ${Date.now() - start}ms`);
       return res;
     })
+      .with(secrets)
       .with(helixStatus)
       .with(logger.trace)
       .with(logger);


### PR DESCRIPTION
necessary pre-req to using the helix secrets manager in actions that use the request handler (ex ingestor)

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
